### PR TITLE
fix: account for multiple parent indents

### DIFF
--- a/test/schema/complex.schema
+++ b/test/schema/complex.schema
@@ -1,0 +1,17 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+type: object
+
+properties:
+    version:
+        type: string
+    general:
+        properties:
+            var1:
+                type:
+                    - array
+                    - string
+            var2:
+                type: string
+            var3:
+                type: string

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -48,6 +48,12 @@ class TestSchemas(unittest.TestCase):
         self.assertEqual(yaml[1].entries[0].key, "entry")
         self.assertEqual(len(yaml[1].entries[0].type), 2)
 
+    def test_complex(self):
+        schema, specials, extra = yamldoc.parser.parse_schema("test/schema/complex.schema", debug = False)
+        self.assertTrue(schema["general"]["var1"] == ["array", "string"])
+        self.assertTrue(schema["general"]["var2"] == "string")
+        self.assertTrue(schema["general"]["var3"] == "string")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Cases with multiple type annotations were:

1. not being recorded correctly in the ledger of indentation levels
2. not being correctly reset when type annotations were finished

resulting in the first de-indentation being trapped in a `continue` statement meant for another case, and the type annotation of that new type over-writing the parent with multiple type annotations. 