### PR TITLE
fix: allow for array-valued entries and fix sequential cases without meta-data; close #6, close #10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - checkout
       - run:
-          command: pip install .
+          command: | 
+            pip install .
+            pip install pyyaml
           name: Install
       - run:
           command: python test/test_examples.py

--- a/test/schema/lists.schema
+++ b/test/schema/lists.schema
@@ -1,0 +1,7 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+
+type: object
+
+properties:
+    this_is_a_list: 
+        type: array

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -31,6 +31,12 @@ class TestYAMLs(unittest.TestCase):
         entries = yamldoc.parse_yaml("test/yaml/URLs.yaml", char = "#'", debug = False)
         self.assertEqual(entries[0].value, "https://github.com/Chris1221/yamldoc")
         self.assertEqual(entries[1].entries[0].value, "https://github.com/Chris1221/yamldoc")
+    
+    def test_list_parsing(self):
+        entries = yamldoc.parse_yaml("test/yaml/lists.yaml", char = "#'", debug = False)
+        self.assertEqual(entries[0].value, ["1", "2", "3"])
+        self.assertTrue(entries[0].meta.strip() == "List metadata")
+
 
 class TestSchemas(unittest.TestCase):
     def test_basic(self):
@@ -47,6 +53,14 @@ class TestSchemas(unittest.TestCase):
         self.assertEqual(yaml[0].type, "string")
         self.assertEqual(yaml[1].entries[0].key, "entry")
         self.assertEqual(len(yaml[1].entries[0].type), 2)
+
+    def test_lists(self):
+        yaml = yamldoc.parse_yaml("test/yaml/lists.yaml", debug = False)
+        schema, specials, extra = yamldoc.parser.parse_schema("test/schema/lists.schema", debug = False)
+        yamldoc.parser.add_type_metadata(schema, yaml)
+        self.assertEqual(yaml[0].value, ["1", "2", "3"])
+        self.assertTrue(yaml[0].meta.strip() == "List metadata")
+        self.assertTrue(yaml[0].type == "array")
 
     def test_complex(self):
         schema, specials, extra = yamldoc.parser.parse_schema("test/schema/complex.schema", debug = False)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1,5 +1,74 @@
 import unittest
 import yamldoc
+import yaml
+import sys
+import io
+
+def check_boolean_cooercion(value, output):
+    """Checks that the boolean cooercion works as expected"""
+    if value:
+        assert "yes" in output
+    elif not value:
+        assert "no" in output
+    else:
+        raise AssertionError
+
+def assert_all_printed(input, output):
+    with open(input) as f:
+        data = yaml.safe_load(f)
+
+    # get all the data keys from the yaml file
+    keys = list(data.keys())
+
+    # assert that all the keys are in the output
+    for key in keys:
+        assert key in output
+
+    # make sure all the values are there 
+    for key in keys:
+        if isinstance(data[key], list):
+            for value in data[key]:
+                assert str(value) in output
+        elif isinstance(data[key], dict):
+            for value in data[key].values():
+                # "yes" and "no" get coersed to True and False
+                # so we need to check for both
+                try:
+                    assert str(value) in output
+                except AssertionError:
+                    check_boolean_cooercion(value, output)
+        
+        elif isinstance(data[key], str):
+            assert data[key] in output
+        elif isinstance(data[key], bool):
+            try:
+                assert str(data[key]) in output
+            except AssertionError:
+                check_boolean_cooercion(data[key], output)
+        elif isinstance(data[key], int):
+            assert str(data[key]) in output
+        elif isinstance(data[key], float):
+            assert str(data[key]) in output
+        else:
+            print(f"Unknown type {type(data[key])} for {key}")
+            print("Please add this type to the test suite, unsure how to handle it.")
+
+    return True
+
+def get_output(path:str, schema=None) -> str:
+    """Retrieves output of YAMLDOC"""
+    old_stdout = sys.stdout
+    new_stdout = io.StringIO()
+    sys.stdout = new_stdout
+
+    _ = yamldoc.main(
+        yaml_path=path,
+        schema_path=schema,
+    )
+    output = new_stdout.getvalue()
+    sys.stdout = old_stdout
+
+    return output
 
 class TestYAMLs(unittest.TestCase):
     def test_basic(self):
@@ -21,6 +90,7 @@ class TestYAMLs(unittest.TestCase):
         self.assertEqual(entries[1].value,known_entries[1].value)
         self.assertEqual(entries[1].meta,known_entries[1].meta)
 
+    
     def test_two_level(self):
         entries = yamldoc.parse_yaml("test/yaml/two_level.yaml", char = "#'", debug = False)
         self.assertEqual(len(entries), 2)
@@ -67,6 +137,29 @@ class TestSchemas(unittest.TestCase):
         self.assertTrue(schema["general"]["var1"] == ["array", "string"])
         self.assertTrue(schema["general"]["var2"] == "string")
         self.assertTrue(schema["general"]["var3"] == "string")
+
+class TestE2E(unittest.TestCase):
+    def test_basic(self):
+        output = get_output("test/yaml/basic.yaml", "test/schema/basic.schema")
+        self.assertTrue(assert_all_printed("test/yaml/basic.yaml", output))
+    
+    def test_two_level(self):
+        output = get_output("test/yaml/two_level.yaml", "test/schema/two_level.schema")
+        self.assertTrue(assert_all_printed("test/yaml/two_level.yaml", output))
+
+    def test_lists(self):
+        output = get_output("test/yaml/lists.yaml", "test/schema/lists.schema")
+        self.assertTrue(assert_all_printed("test/yaml/lists.yaml", output))
+
+    def test_url(self):
+        output = get_output("test/yaml/URLs.yaml")
+        self.assertTrue(assert_all_printed("test/yaml/URLs.yaml", output))
+
+    def test_long(self):
+        output = get_output("test/yaml/long.yaml")
+        self.assertTrue(assert_all_printed("test/yaml/long.yaml", output))
+
+    
 
 
 if __name__ == '__main__':

--- a/test/yaml/lists.yaml
+++ b/test/yaml/lists.yaml
@@ -1,0 +1,6 @@
+#' List metadata
+this_is_a_list:
+  #' Ignore me
+  - 1
+  - 2
+  - 3

--- a/test/yaml/long.yaml
+++ b/test/yaml/long.yaml
@@ -1,0 +1,32 @@
+test1: 
+  a: 1
+  b: 2
+
+#' meta
+test2:
+  c: 3
+  d: 4
+
+list:
+  - "hi"
+  - "hello"
+
+test3:
+  e: 5
+  f: 6
+
+foo: bar
+blah: 5
+test: yes
+
+test4:
+  g: 7
+  h: 8
+
+test5:
+  entry:
+    i: 9
+    j: 10
+  entry2:
+    k: 11
+    l: 12

--- a/yamldoc/entries.py
+++ b/yamldoc/entries.py
@@ -1,4 +1,5 @@
 import textwrap
+from dataclasses import dataclass
 
 class MetaEntry:
     """ 
@@ -18,6 +19,18 @@ class MetaEntry:
         self.isBase = True
         self.entries = []
         self.has_schema = False
+
+    def is_list(self):
+        """Returns True if all elements are list elements and False otherwise."""
+        return all([isinstance(entry, ListElement) for entry in self.entries])
+    
+    def to_list_entry(self):
+        """Converts this meta instance to a base level list entry."""
+        if self.is_list():
+            values = [entry.entry for entry in self.entries]
+
+            return Entry(self.name, values, self.meta)
+
 
     def __repr__(self):
         """
@@ -61,7 +74,10 @@ class MetaEntry:
 
             return output
 
-        
+@dataclass
+class ListElement:
+    entry: str
+
 
 class Entry:
     """

--- a/yamldoc/parser.py
+++ b/yamldoc/parser.py
@@ -66,8 +66,10 @@ def parse_yaml(file_path, char = "#'", debug = False):
                     if len(line) - len(line.lstrip(' ')) == 0:
                         # Is current_entry a list or a meta-entry?
                         if current_entry.is_list():
+                            if debug: print("@\tAdding list entry to things.")
                             things.append(current_entry.to_list_entry())
                         else:
+                            if debug: print("@\tAdding meta entry to things.")
                             things.append(current_entry)
                         current_entry = None
                         continue
@@ -85,7 +87,8 @@ def parse_yaml(file_path, char = "#'", debug = False):
                             # If there's only one value, it's a list.
                             # in this case, we add ths value to the 
                             # current entry and continue.
-                            current_entry.entries.append(yamldoc.entries.ListElement(line.lstrip().rstrip()))
+                            if debug: print("@\tFound a list entry.")
+                            current_entry.entries.append(yamldoc.entries.ListElement(line.lstrip().lstrip("-").lstrip().rstrip()))
 
 
 
@@ -169,9 +172,6 @@ def parse_schema(path_to_file, debug = False):
                 value = None
 
             
-            #if key == "var2": breakpoint()
-
-
             # This is awkwardly placed but we have to deal
             # with a special case where lines 
             # start with a dash, and indicate that


### PR DESCRIPTION
Add a special kind of `meta-entry` that corresponds to a list-type. To do this, add special `ListElement` valued entries to a meta-entry and check before insertion whether all elements are ListElements; if so, convert to a regular entry and add. 