### PR TITLE
feat: selectively exclude entries fix #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ This will install the python package, which contains a command line interface `y
 yamldoc -h
 ```
 
+## Features and Supported Syntax 
+
+`yamldoc` does not support the full syntax of YAML, which is vast and complex. Instead, it supports a subset of YAML that is useful for documenting configuration files. This subset includes:
+
+| Syntax | Supported | Description |
+| --- | --- | --- |
+| `key: value` | Yes | Basic key-value pairs. Values can be any type and are not subject to coercion. (i.e. `yes` will remain `yes` in `yamldoc` output. It will not be coerced to `True` as a YAML parser would. The goal of `yamldoc` is to be **transparent**, not feature complete. |
+| `key: [value1, value2, ...]` | Yes | Arrays are understood by yamldoc if they are either listed on one line or each entry given on a new line with dashes to indicate entries. |
+| Comments | Yes | Non-`yamldoc` comments are ignored. `yamldoc` comments are indicated by a special character (default `#'`) at the beginning of the line. `yamldoc` comments can be broken over as many lines as you like, they will be added together when the markdown is constructed. |
+
+Things YAML does not support: 
+
+- Nested arrays past two levels of nesting. `yamldoc` will not parse nested arrays past two levels of nesting. [Issue #14](https://github.com/Chris1221/yamldoc/issues/14) tracks this request. 
+- Multi-line strings (unquoted or quoted scalars) indicated by `|` or `>` are not supported.
+- Lists of dictionaries are not supported.
+- Multiple documents in a single file are supported, but no special handling is done to separate them. It is assumed that each document is a separate configuration file.
+- Complex mapping keys starting with `!!` or `?` are not supported. `yamldoc` will not parse complex mappings, tags, or explicit tags. 
+
 
 ## Philosophy
 
@@ -61,3 +79,14 @@ yamldoc test/yaml/basic.yaml -c "YOURCHAR"
 - `_yamldoc_description`: A description to follow the title. 
 
 These are picked out of the schema file and reported. 
+
+`yamldoc` has support for skipping individual entries in the reported markdown. Note this is seperate from adding comments that are not meta-data, these are respected and never reported. Skipping refers to actual entries in the YAML file. To skip an entry, add the skip character (by default, `#'!`) to the beginning of the line. 
+
+```yaml
+# This is a comment, it will not be reported
+#' This entry will be included in the report 
+entry1: value1
+
+#'! This entry will be skipped
+entry2: value2
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,24 @@ This package was designed specifically to document the possible configuration op
 
 For more details on using YAML to configure Snakemake pipelines, see [here](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html).
 
+## Features and Supported Syntax 
+
+`yamldoc` does not support the full syntax of YAML, which is vast and complex. Instead, it supports a subset of YAML that is useful for documenting configuration files. This subset includes:
+
+| Syntax | Supported | Description |
+| --- | --- | --- |
+| `key: value` | Yes | Basic key-value pairs. Values can be any type and are not subject to coercion. (i.e. `yes` will remain `yes` in `yamldoc` output. It will not be coerced to `True` as a YAML parser would. The goal of `yamldoc` is to be **transparent**, not feature complete. |
+| `key: [value1, value2, ...]` | Yes | Arrays are understood by yamldoc if they are either listed on one line or each entry given on a new line with dashes to indicate entries. |
+| Comments | Yes | Non-`yamldoc` comments are ignored. `yamldoc` comments are indicated by a special character (default `#'`) at the beginning of the line. `yamldoc` comments can be broken over as many lines as you like, they will be added together when the markdown is constructed. |
+
+Things YAML does not support: 
+
+- Nested arrays past two levels of nesting. `yamldoc` will not parse nested arrays past two levels of nesting. [Issue #14](https://github.com/Chris1221/yamldoc/issues/14) tracks this request. 
+- Multi-line strings (unquoted or quoted scalars) indicated by `|` or `>` are not supported.
+- Lists of dictionaries are not supported.
+- Multiple documents in a single file are supported, but no special handling is done to separate them. It is assumed that each document is a separate configuration file.
+- Complex mapping keys starting with `!!` or `?` are not supported. `yamldoc` will not parse complex mappings, tags, or explicit tags. 
+
 ## Example Files
 
 For a minimal example of `yamldoc`, see the files in `/test/yaml` and `/test/schema`.
@@ -56,3 +74,15 @@ yamldoc test/yaml/basic.yaml -c "YOURCHAR"
 - `_yamldoc_description`: A description to follow the title. 
 
 These are picked out of the schema file and reported.
+
+
+`yamldoc` has support for skipping individual entries in the reported markdown. Note this is seperate from adding comments that are not meta-data, these are respected and never reported. Skipping refers to actual entries in the YAML file. To skip an entry, add the skip character (by default, `#'!`) to the beginning of the line. 
+
+```yaml
+# This is a comment, it will not be reported
+#' This entry will be included in the report 
+entry1: value1
+
+#'! This entry will be skipped
+entry2: value2
+```

--- a/test/test_exclude.py
+++ b/test/test_exclude.py
@@ -1,4 +1,3 @@
-import markdown as md
 import yamldoc
 
 

--- a/test/test_exclude.py
+++ b/test/test_exclude.py
@@ -1,0 +1,45 @@
+import markdown as md
+import yamldoc
+
+
+def test_simple_exclusion():
+    yaml = yamldoc.parse_yaml(
+        "test/yaml/exclusion/simple_exclusion.yaml", exclude_char="#'!"
+    )
+
+    assert len(yaml) == 2, "Both entries should be included."
+
+    entry1, entry2 = yaml
+
+    assert entry1.key == "key1", "Entry 1 should be included."
+    assert entry2.key == "key2", "Entry 2 should be included."
+
+    assert entry1.exclude == False, "Entry 1 should not be excluded."
+    assert entry2.exclude == True, "Entry 2 should be excluded."
+
+    assert entry1.value == "Data", "Entry 1 should have value 'value1'."
+    assert entry2.value == "True", "Entry 2 should have value 'value2'."
+
+
+def test_complex_exclusion():
+    yaml = yamldoc.parse_yaml(
+        "test/yaml/exclusion/complex_exclusion.yaml", exclude_char="#'!"
+    )
+
+    assert len(yaml) == 9, "All entries should be included."
+
+    excluded = [entry for entry in yaml if entry.exclude]
+    assert len(excluded) == 2, "Two entries should be excluded."
+
+    # The last one is a subentry, so we need to get that one
+
+    meta_entries = [entry for entry in yaml if hasattr(entry, "name")]
+    assert len(meta_entries) == 5, "There should be 7 meta entries."
+
+    entry1, entry2, entry3, entry4, entry5 = meta_entries
+
+    for e in entry1, entry2, entry3, entry5:
+        assert e.exclude == False, "Entry should not be excluded."
+
+    assert entry5.entries[0].exclude == True, "Entry should be excluded."
+    assert entry5.entries[1].exclude == False, "Entry should not be excluded."

--- a/test/test_exclude.py
+++ b/test/test_exclude.py
@@ -42,3 +42,12 @@ def test_complex_exclusion():
 
     assert entry5.entries[0].exclude == True, "Entry should be excluded."
     assert entry5.entries[1].exclude == False, "Entry should not be excluded."
+
+def test_nested_list():
+    yaml = yamldoc.parse_yaml(
+        "test/yaml/exclusion/nested_list.yaml", exclude_char="#'!"
+    )
+
+    assert len(yaml) == 1, "All entries should be included."
+    assert yaml[0].to_markdown(), "Should be able to print the entry."
+    

--- a/test/yaml/exclusion/complex_exclusion.yaml
+++ b/test/yaml/exclusion/complex_exclusion.yaml
@@ -33,3 +33,7 @@ test5:
   entry2:
     k: 11
     l: 12
+  array1:
+    - 1
+    - 2
+    - 3

--- a/test/yaml/exclusion/complex_exclusion.yaml
+++ b/test/yaml/exclusion/complex_exclusion.yaml
@@ -1,0 +1,35 @@
+test1: 
+  a: 1
+  b: 2
+
+#' meta
+test2:
+  c: 3
+  d: 4
+
+#'! Don't include this one! 
+list:
+  - "hi"
+  - "hello"
+
+test3:
+  e: 5
+  f: 6
+
+foo: bar
+blah: 5
+test: yes
+
+#'! Or this one! 
+test4:
+  g: 7
+  h: 8
+
+test5:
+  #'! Bad bad bad 
+  entry:
+    i: 9
+    j: 10
+  entry2:
+    k: 11
+    l: 12

--- a/test/yaml/exclusion/nested_list.yaml
+++ b/test/yaml/exclusion/nested_list.yaml
@@ -1,0 +1,4 @@
+base:
+  level1:
+    -red
+    -blue

--- a/test/yaml/exclusion/simple_exclusion.yaml
+++ b/test/yaml/exclusion/simple_exclusion.yaml
@@ -1,0 +1,5 @@
+#' Here is some meta data.
+key1: Data
+
+#'! This entry should be ignored
+key2: True

--- a/yamldoc/cli.py
+++ b/yamldoc/cli.py
@@ -3,20 +3,30 @@ import argparse
 
 
 def cli():
-    """Example of taking inputs for megazord bin"""
     parser = argparse.ArgumentParser(prog="YAML Documentation Engine")
-    parser.add_argument("file", help="YAML file.")
+    parser.add_argument("yaml_path", help="YAML file.")
     parser.add_argument("-c", "--char", default="#'", help="Metadata character prefix.")
     parser.add_argument(
         "-d", "--debug", action="store_true", help="Show debug information."
     )
     parser.add_argument(
         "-s",
-        "--schema",
+        "--schema-path",
         default=None,
         help="(Optional) Schema file describing variable types.",
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude-char",
+        default="#'!",
+        help="Prefix to exclude the following entry from generated documentation.",
+    )
+    parser.add_argument(
+        "--override-exclude",
+        action="store_true",
+        help="Override the exclusion character and force inclusion of all entries.",
     )
 
     args = parser.parse_args()
 
-    yamldoc.main(args.file, args.char, args.debug, args.schema)
+    yamldoc.main(**(vars(args)))

--- a/yamldoc/entries.py
+++ b/yamldoc/entries.py
@@ -76,11 +76,9 @@ class MetaEntry:
         """
         if self.has_schema:
             return (
-                f"YAML Meta Object with {len(self.entries)} entries [{self.name}] and"
-                " type information."
-            )
+                f"Meta object (n = {len(self.entries)}) with schema: {self.entries}" )
         else:
-            return f"YAML Meta Object with {len(self.entries)} entries [{self.name}]"
+            return f"Meta object (n = {len(self.entries)}) without schema: {self.entries}"
 
     def non_excluded_entries(self):
         """Returns a list of entries that are not excluded."""
@@ -99,6 +97,17 @@ class MetaEntry:
             """)
 
         return header
+    
+    def check_for_lists(self):
+        new_entries = []
+        for entry in self.entries:
+            if isinstance(entry, MetaEntry):
+                if entry.is_list():
+                    new_entries.append(entry.to_list_entry())
+                    continue
+            new_entries.append(entry)
+        
+        self.entries = new_entries
 
     def to_markdown(self, schema=False):
         """
@@ -111,7 +120,11 @@ class MetaEntry:
         # If the object is excluded, we don't want to print anything.
         if self.exclude:
             return ""
-
+        
+        # Check for any sublists that need to be converted
+        # from meta to entries
+        self.check_for_lists()
+        
         # Regardles of whether or not there are entries to print, we still want to print the
         # meta information.
         output = f"## `{self.name}`\n\n{self.meta.lstrip()}\n\n"
@@ -136,6 +149,7 @@ class MetaEntry:
 @dataclass
 class ListElement:
     entry: str
+    exclude: bool = False 
 
 
 class Entry:

--- a/yamldoc/entries.py
+++ b/yamldoc/entries.py
@@ -2,13 +2,41 @@ import textwrap
 from dataclasses import dataclass
 
 
+def sanitize_meta(meta, char, exclude_char="#'!", override_exclude=False):
+    """
+    Sanitizes the meta information and indicates
+    whether or not the entry should be excluded.
+
+    Arguments:
+        meta: The meta information to sanitize.
+        override_exclude: Override the exclusion character and force inclusion.
+    """
+
+    meta = meta.lstrip().rstrip()
+
+    if meta.startswith(exclude_char):
+        exclude = True
+    else:
+        exclude = False
+
+    if meta.startswith(exclude_char):
+        meta = meta.replace(exclude_char, "").lstrip()
+    elif meta.startswith(char):
+        meta = meta.replace(char, "").lstrip()
+
+    if override_exclude:
+        exclude = False
+
+    return meta, exclude
+
+
 class MetaEntry:
     """
     A container to hold a base level YAML entry plus any associated
     hierarchical keys and values.
     """
 
-    def __init__(self, name, meta):
+    def __init__(self, name, meta, char, exclude_char="#'!", override_exclude=False):
         """
         Initialize the object.
 
@@ -17,31 +45,60 @@ class MetaEntry:
             meta: Comments derived from YAML file.
         """
         self.name = name
-        self.meta = meta
+        self.char = char
+        self.exclude_char = exclude_char
         self.isBase = True
         self.entries = []
         self.has_schema = False
 
+        self.meta, self.exclude = sanitize_meta(meta, char, exclude_char, override_exclude)
+
     def is_list(self):
         """Returns True if all elements are list elements and False otherwise."""
         return all([isinstance(entry, ListElement) for entry in self.entries])
-    
+
     def to_list_entry(self):
         """Converts this meta instance to a base level list entry."""
         if self.is_list():
             values = [entry.entry for entry in self.entries]
+            entry = Entry(self.name, values, self.meta, self.char, self.exclude_char)
+            
+            # Small detail here, the meta has already been parsed
+            # so we don't want to do it again.
+            if self.exclude:
+                entry.exclude = True
 
-            return Entry(self.name, values, self.meta)
-
+            return entry
 
     def __repr__(self):
         """
         Returns a print representation.
         """
         if self.has_schema:
-            return f"YAML Meta Object with {len(self.entries)} entries [{self.name}] and type information."
+            return (
+                f"YAML Meta Object with {len(self.entries)} entries [{self.name}] and"
+                " type information."
+            )
         else:
             return f"YAML Meta Object with {len(self.entries)} entries [{self.name}]"
+
+    def non_excluded_entries(self):
+        """Returns a list of entries that are not excluded."""
+        return [entry for entry in self.entries if not entry.exclude]
+
+    def table_header(self, schema=False):
+        if schema:
+            header = textwrap.dedent("""
+            | Key | Value | Type | Information |
+            | :-: | :-: | :-: | :-- |
+            """)
+        else:
+            header = textwrap.dedent("""
+            | Key | Value | Information |
+            | :-: | :-: | :-- |
+            """)
+
+        return header
 
     def to_markdown(self, schema=False):
         """
@@ -50,28 +107,30 @@ class MetaEntry:
         Argumenets:
             schema: Print with four columns instead of three.
         """
-        if schema:
-            output = f"## `{self.name}`\n\n{self.meta.lstrip()}\n\n"
-            output += "### Member variables:\n\n"
 
-            output += "| Key | Value | Type | Information |\n"
-            output += "| :-: | :-: | :-: | :-- |\n"
+        # If the object is excluded, we don't want to print anything.
+        if self.exclude:
+            return ""
 
-            for entry in self.entries:
-                output += entry.to_markdown(schema) + "\n"
-            return output
+        # Regardles of whether or not there are entries to print, we still want to print the
+        # meta information.
+        output = f"## `{self.name}`\n\n{self.meta.lstrip()}\n\n"
 
-        else:
-            output = f"## `{self.name}`\n\n{self.meta.lstrip()}\n\n"
-            output += "### Member variables:\n\n"
-
-            output += "| Key | Value | Information |\n"
-            output += "| :-: | :-: | :-- |\n"
-
-            for entry in self.entries:
-                output += entry.to_markdown() + "\n"
+        # This is an early exit if there are no entries to print.
+        entries_to_print = self.non_excluded_entries()
+        if len(entries_to_print) == 0:
+            output += "No member variables.\n\n"
 
             return output
+
+        # So we have entries to print. Let's print them.
+        output += "### Member variables:\n\n"
+        output += self.table_header(schema)
+
+        for entry in entries_to_print:
+            output += entry.to_markdown(schema) + "\n"
+
+        return output
 
 
 @dataclass
@@ -83,7 +142,9 @@ class Entry:
     """
     Container for a single YAML key value pairing and associated metadata."""
 
-    def __init__(self, key, value, meta):
+    def __init__(
+        self, key, value, meta, char="#'", exclude_char="#'!", override_exclude=False
+    ):
         """
         Initialize the object
 
@@ -91,19 +152,30 @@ class Entry:
            key: Name of the value
            value: Given value.
            meta: Any associated comments or meta data.
+            char: Character to denote meta data.
+            exclude_char: Character to denote exclusion.
+            override_exclude: Override the exclusion character and force inclusion.
         """
         self.key = key
         self.value = value
-        self.meta = meta
+        self.char = char
+        self.exclude_char = exclude_char
         self.isBase = False
         self.type = None
+
+        self.meta, self.exclude = sanitize_meta(
+            meta, char, exclude_char, override_exclude
+        )
 
     def __repr__(self):
         """
         Gives a print representation for the class.
         """
         if self.type is not None:
-            return f"YAML Entry [{self.key}: {self.value}]\n\t Meta: {self.meta}\n\t Type: {self.type}"
+            return (
+                f"YAML Entry [{self.key}: {self.value}]\n\t Meta: {self.meta}\n\t Type:"
+                f" {self.type}"
+            )
         else:
             return f"YAML Entry [{self.key}: {self.value}]\n\t Meta: {self.meta}"
 
@@ -114,6 +186,11 @@ class Entry:
         Arguments:
             schema: Print with four columns instead of three.
         """
+
+        # If the entry is excluded, we don't want to print it.
+        if self.exclude:
+            return ""
+        
         if schema:
             m = "<br />".join(textwrap.wrap(self.meta, width=50))
             if self.type == None:

--- a/yamldoc/parser.py
+++ b/yamldoc/parser.py
@@ -2,7 +2,7 @@ import yamldoc.entries
 from datetime import date
 
 
-def parse_yaml(file_path, char="#'", debug=False):
+def parse_yaml(file_path, char="#'", debug=False, exclude_char="#'!", override_exclude=False):
     """
     Parse a YAML file and return a list of YAML classes.
 
@@ -10,13 +10,22 @@ def parse_yaml(file_path, char="#'", debug=False):
         file_path: Path to the YAML file.
         char: A character string used to identify yamldoc blocks.
         debug: Print debug information
+        exclude_char: A character string used to identify blocks to exclude.
+
 
     Return:
         List of YAML blocks.
     """
-    # YAML files have key value pairings seperated by
-    # newlines. The most straightforward kind of things to parse will be
-    # keyvalue pairs preceeded by comments with the Doxygen marker #'
+
+    # The parser works as follows:
+    #   YAML files have key value pairings seperated by
+    #   newlines. The most straightforward kind of things to parse will be
+    #   keyvalue pairs preceeded by comments with the Doxygen marker #'
+    #   (or whatever the user specifies). The parser will look for these
+    #   comments and then parse the key value pairs that follow. The
+    #   parser will then look for the next comment and repeat the
+    #   process. The parser will also look for a comment that starts with
+    #   the exclude_char and ignore the following block.
 
     current_entry = None
     meta = ""
@@ -24,42 +33,59 @@ def parse_yaml(file_path, char="#'", debug=False):
 
     with open(file_path) as yaml:
         for line in [l for l in yaml.readlines() if l.rstrip()]:
-            if debug: print(line.rstrip())
+            if debug:
+                print(line.rstrip())
 
             if current_entry is not None:
                 if current_entry.isBase:
-
                     # If we're back at 0 indentation, the
                     # block is done and we need to quit.
-                    if len(line) - len(line.lstrip(' ')) == 0:
+                    if len(line) - len(line.lstrip(" ")) == 0:
                         # Is current_entry a list or a meta-entry?
                         if current_entry.is_list():
-                            if debug: print("@\tAdding list entry to things.")
+                            if debug:
+                                print("@\tAdding list entry to things.")
                             things.append(current_entry.to_list_entry())
                         else:
-                            if debug: print("@\tAdding meta entry to things.")
+                            if debug:
+                                print("@\tAdding meta entry to things.")
                             things.append(current_entry)
                         current_entry = None
-                        
 
                     # If not, continue parsing the sub entries.
-                    # 
+                    #
                     if current_entry is not None:
-                        if line.lstrip(' ').startswith(char):
-                            meta = meta + line.lstrip().lstrip(char).rstrip()
+                        if line.lstrip(" ").startswith(char) or line.lstrip(
+                            " "
+                        ).startswith(exclude_char):
+                            meta = meta + line.lstrip().rstrip()
                         else:
                             try:
                                 key, value = line.lstrip().rstrip().split(":", 1)
-                                current_entry.entries.append(yamldoc.entries.Entry(key, value.lstrip(' '), meta.lstrip()))
-                                if debug: print("@\tFound an entry and deposited it in meta.")
+                                current_entry.entries.append(
+                                    yamldoc.entries.Entry(
+                                        key,
+                                        value.lstrip(" "),
+                                        meta.lstrip(),
+                                        char,
+                                        exclude_char,
+                                        override_exclude
+                                    )
+                                )
+                                if debug:
+                                    print("@\tFound an entry and deposited it in meta.")
                                 meta = ""
                             except ValueError:
                                 # If there's only one value, it's a list.
-                                # in this case, we add ths value to the 
+                                # in this case, we add ths value to the
                                 # current entry and continue.
-                                if debug: print("@\tFound a list entry.")
-                                current_entry.entries.append(yamldoc.entries.ListElement(line.lstrip().lstrip("-").lstrip().rstrip()))
-
+                                if debug:
+                                    print("@\tFound a list entry.")
+                                current_entry.entries.append(
+                                    yamldoc.entries.ListElement(
+                                        line.lstrip().lstrip("-").lstrip().rstrip()
+                                    )
+                                )
 
             # Either we haven't started yet
             # or we've just flushed the entry.
@@ -73,7 +99,7 @@ def parse_yaml(file_path, char="#'", debug=False):
                 if nspaces == 0:
                     current_entry = None
                     if line.startswith(char):
-                        meta = meta + line.lstrip(char).rstrip()
+                        meta = meta + line.rstrip()
                     else:
                         key, value = line.rstrip().split(":", 1)
 
@@ -83,7 +109,9 @@ def parse_yaml(file_path, char="#'", debug=False):
                         # This could also be a simple list entry but I can't
                         # know that until I see the next line.
                         if not value.lstrip():
-                            current_entry = yamldoc.entries.MetaEntry(key, meta)
+                            current_entry = yamldoc.entries.MetaEntry(
+                                key, meta, char, exclude_char, override_exclude
+                            )
 
                             # Metadata must be flushed after being added as a parent
                             # element
@@ -97,13 +125,17 @@ def parse_yaml(file_path, char="#'", debug=False):
                         else:
                             things.append(
                                 yamldoc.entries.Entry(
-                                    key, value.lstrip(" "), meta.lstrip()
+                                    key,
+                                    value.lstrip(" "),
+                                    meta.lstrip(),
+                                    char,
+                                    exclude_char,
+                                    override_exclude
                                 )
                             )
                             if debug:
                                 print("@\tFound an entry.")
                             meta = ""
-
 
         # The file might run out
         # before the final meta
@@ -187,7 +219,6 @@ def parse_schema(path_to_file, debug=False):
                 key = key_value(line)
                 value = None
 
-
             # This is awkwardly placed but we have to deal
             # with a special case where lines
             # start with a dash, and indicate that
@@ -202,8 +233,8 @@ def parse_schema(path_to_file, debug=False):
                     special_type_case = False
                 elif line.lstrip(" ").startswith("-"):
                     value = line.lstrip(" ").lstrip("- ").rstrip()
-                    current[parent][name].append(value) # noqa: F821
-                    indents[parent][name].append(indent[1]) # noqa: F821
+                    current[parent][name].append(value)  # noqa: F821
+                    indents[parent][name].append(indent[1])  # noqa: F821
                     continue
                 else:
                     raise TypeError("You must specify a value for type.")
@@ -425,6 +456,8 @@ def main(
     char="#'",
     debug=False,
     schema_path=None,
+    exclude_char="#'!",
+    override_exclude = False,
     title="Configuration Parameters Reference",
     description="Any information about this page goes here.",
     footer=True,
@@ -451,7 +484,7 @@ def main(
     # variables.
     if schema_path is not None:
         schema, specials, extras = parse_schema(schema_path, debug)
-        yaml = parse_yaml(yaml_path, char, debug)
+        yaml = parse_yaml(yaml_path, char, debug, exclude_char, override_exclude)
 
         # Edit the yaml in place with type information.
         add_type_metadata(schema, yaml, debug)
@@ -467,8 +500,8 @@ def main(
 
         # Build the table with top level yaml
 
-        # We only need to print this if there's no 
-        # top level variable first 
+        # We only need to print this if there's no
+        # top level variable first
         if not yaml[0].isBase:
             print("| Key | Value | Type | Information |")
             print("| :-: | :-: | :-: | :-- |")
@@ -492,7 +525,7 @@ def main(
     else:
         print("# " + title + "\n\n" + description + "\n")
 
-        yaml = parse_yaml(yaml_path, char, debug)
+        yaml = parse_yaml(yaml_path, char, debug, exclude_char, override_exclude)
         # Build the table with top level yaml
 
         # We only need to print this if there's no
@@ -500,7 +533,7 @@ def main(
         if not yaml[0].isBase:
             print("| Key | Value | Information |")
             print("| :-: | :-: | :-- |")
-        
+
         for value in yaml:
             if not value.isBase:
                 print(value.to_markdown())


### PR DESCRIPTION
Enables the use of an "exclusion character" to skip documentation on certain lines. Exclusion character can be specified on the command line as `-e` and defaults to `#'!`.

For example:

`test.yaml`:

```yaml
array_1:
  - 1
  - 2
  - 3

#'! Ignored in documentation
array_2:
  - 4
  - 5
  - 6
```

Generates

| Key | Value | Information |
| :-: | :-: | :-- |
| `array_1` | `['1', '2', '3']` |  |


I've also added an `--override-exclude` switch to ignore these directives. If this switch is specified, then the meta-data is still read in as normal.

```
yamldoc test.yaml --override-exclude
```

Produces 

| Key | Value | Information |
| :-: | :-: | :-- |
| `array_1` | `['1', '2', '3']` |  |
| `array_2` | `['4', '5', '6']` | Ignored in documentation |